### PR TITLE
Add args to build-config

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -84,4 +84,4 @@ const buildConfig = async (
   await copyThemeFile({ dist, styleSystem, actionPath });
 };
 
-buildConfig(args[0], args[1]);
+buildConfig(args[0], args[1], args[2], args[3]);


### PR DESCRIPTION
Found that build config was not being passed all required arguments. This resulted in the action only generating the default style system (tailwind). I believe this is also why the the template themes were not being generated when the action is called.