### PR TITLE
LineHeight Fix

### DIFF
--- a/action-scripts/build.js
+++ b/action-scripts/build.js
@@ -14,8 +14,9 @@ const build = () => {
     // We're checking for a 'value' key this way, rather than a simple obj.value check
     // because we want to avoid a false negative if obj.value resolves to a falsy value
     const hasAValueKey = Object.keys(obj).includes("value");
+    const value = key === 'lineHeight' ? parseLineHeight(obj?.value) : obj?.value;
 
-    return hasAValueKey ? [key, obj?.value] : [key, getEntries()];
+    return hasAValueKey ? [key, value] : [key, getEntries()];
   };
 
   const formatEntries = (entries) =>

--- a/action-scripts/build.js
+++ b/action-scripts/build.js
@@ -14,7 +14,7 @@ const build = () => {
     // We're checking for a 'value' key this way, rather than a simple obj.value check
     // because we want to avoid a false negative if obj.value resolves to a falsy value
     const hasAValueKey = Object.keys(obj).includes("value");
-    const value = key === 'lineHeight' ? parseLineHeight(obj?.value) : obj?.value;
+    const value = (key === 'lineHeight' || key === 'fontSize') ? parseLineHeight(obj?.value) : obj?.value;
 
     return hasAValueKey ? [key, value] : [key, getEntries()];
   };


### PR DESCRIPTION
Resolves an issue where `lineHeight` & `fontSize` were being output as a number value instead of a pixel value:
- ❌ `lineHeight: 112` vs ✅ `lineHeight: 112px`.
-  ❌ `fontSize: 35` vs ✅ `fontSize: 35px`.