### PR TITLE
Address typography script

### DIFF
--- a/action-scripts/build.ts
+++ b/action-scripts/build.ts
@@ -203,11 +203,8 @@ const build = () => {
       innerItems.forEach(([item, v]) => {
         const variants = Object.entries(v);
         const firstChildVal = variants[0][1];
-        if (
-          typeof firstChildVal === "string" ||
-          typeof firstChildVal === "number"
-        ) {
-          expanded[item] = v;
+        if (typeof firstChildVal === "string") {
+          expanded[k] = v;
           return;
         }
         variants.forEach(([variant, value]) => {

--- a/action-scripts/build.ts
+++ b/action-scripts/build.ts
@@ -201,12 +201,31 @@ const build = () => {
       const innerItems = Object.entries(v);
 
       innerItems.forEach(([item, v]) => {
-        const variants = Object.entries(v);
+        const variants: Variant[] = Object.entries(v);
         const firstChildVal = variants[0][1];
         if (typeof firstChildVal === "string") {
           expanded[k] = v;
           return;
         }
+
+        const defaultVal = variants.reduce((prev, curr): Variant => {
+          const [prevVariant] = prev;
+          const [currVariant] = curr;
+          if (prevVariant === "regular" || prevVariant === "default")
+            return prev;
+          if (currVariant === "regular" || currVariant === "default")
+            return curr;
+
+          if (parseInt(prevVariant) < parseInt(currVariant)) {
+            return prev;
+          } else if (parseInt(prevVariant) > parseInt(currVariant)) return curr;
+          return prev;
+        }, variants[0])[1];
+
+        expanded[item] = expanded[item]
+          ? { ...expanded[item], ...defaultVal }
+          : defaultVal;
+
         variants.forEach(([variant, value]) => {
           expanded[item + "-" + variant] = value;
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4759,15 +4759,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
     "node_modules/husky": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
@@ -12148,16 +12139,11 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true
-    },
     "husky": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
-      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg=="
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "dev": true
     },
     "ignore": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "prepare": "husky install",
-    "build-tailwind": "node --experimental-specifier-resolution=node --loader ts-node/esm main.ts tokens/raw/tokens.json build tailwind"
+    "build-tailwind": "node --experimental-specifier-resolution=node --loader ts-node/esm main.ts tokens/raw/tokens.json build tailwind",
+    "build-mui": "node --experimental-specifier-resolution=node --loader ts-node/esm main.ts tokens/raw/tokens.json build mui"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "headway-shipwright-token-style",
   "version": "1.0.0",
   "description": "to be determined",
-  "main": "index.js",
+  "main": "main.ts",
   "type": "module",
   "scripts": {
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "build-tailwind": "node --experimental-specifier-resolution=node --loader ts-node/esm main.ts tokens/raw/tokens.json build tailwind"
   },
   "repository": {
     "type": "git",

--- a/tokens/raw/tokens.json
+++ b/tokens/raw/tokens.json
@@ -1,5 +1,9 @@
 {
   "global": {
+    "_helper Type 20": {
+      "value": "#32455233",
+      "type": "color"
+    },
     "color set": {
       "primary": {
         "main": {
@@ -39,7 +43,7 @@
             "value": "#202020cc",
             "type": "color"
           },
-          "tertairy": {
+          "tertiary": {
             "value": "#202020b3",
             "type": "color"
           },
@@ -260,10 +264,10 @@
       "display": {
         "value": {
           "fontFamily": "{fontFamilies.inter}",
-          "fontWeight": "{fontWeights.inter-9}",
+          "fontWeight": "{fontWeights.inter-8}",
           "lineHeight": "{lineHeights.15}",
-          "fontSize": "{fontSize.16}",
-          "letterSpacing": "{letterSpacing.13}",
+          "fontSize": "{fontSize.23}",
+          "letterSpacing": "{letterSpacing.11}",
           "paragraphSpacing": "{paragraphSpacing.0}",
           "textCase": "{textCase.uppercase}",
           "textDecoration": "{textDecoration.none}"
@@ -273,9 +277,9 @@
       "subtitle--regular": {
         "value": {
           "fontFamily": "{fontFamilies.source-sans-pro}",
-          "fontWeight": "{fontWeights.source-sans-pro-10}",
+          "fontWeight": "{fontWeights.source-sans-pro-9}",
           "lineHeight": "{lineHeights.6}",
-          "fontSize": "{fontSize.2}",
+          "fontSize": "{fontSize.3}",
           "letterSpacing": "{letterSpacing.2}",
           "paragraphSpacing": "{paragraphSpacing.0}",
           "textCase": "{textCase.none}",
@@ -286,9 +290,9 @@
       "subtitle--bold": {
         "value": {
           "fontFamily": "{fontFamilies.source-sans-pro}",
-          "fontWeight": "{fontWeights.source-sans-pro-11}",
+          "fontWeight": "{fontWeights.source-sans-pro-10}",
           "lineHeight": "{lineHeights.6}",
-          "fontSize": "{fontSize.3}",
+          "fontSize": "{fontSize.4}",
           "letterSpacing": "{letterSpacing.2}",
           "paragraphSpacing": "{paragraphSpacing.0}",
           "textCase": "{textCase.none}",
@@ -299,9 +303,9 @@
       "title": {
         "value": {
           "fontFamily": "{fontFamilies.source-sans-pro}",
-          "fontWeight": "{fontWeights.source-sans-pro-11}",
+          "fontWeight": "{fontWeights.source-sans-pro-10}",
           "lineHeight": "{lineHeights.16}",
-          "fontSize": "{fontSize.13}",
+          "fontSize": "{fontSize.17}",
           "letterSpacing": "{letterSpacing.2}",
           "paragraphSpacing": "{paragraphSpacing.0}",
           "textCase": "{textCase.none}",
@@ -312,9 +316,9 @@
       "body": {
         "value": {
           "fontFamily": "{fontFamilies.source-sans-pro}",
-          "fontWeight": "{fontWeights.source-sans-pro-10}",
+          "fontWeight": "{fontWeights.source-sans-pro-9}",
           "lineHeight": "{lineHeights.10}",
-          "fontSize": "{fontSize.3}",
+          "fontSize": "{fontSize.4}",
           "letterSpacing": "{letterSpacing.2}",
           "paragraphSpacing": "{paragraphSpacing.0}",
           "textCase": "{textCase.none}",
@@ -325,9 +329,9 @@
       "subheading": {
         "value": {
           "fontFamily": "{fontFamilies.source-sans-pro}",
-          "fontWeight": "{fontWeights.source-sans-pro-12}",
+          "fontWeight": "{fontWeights.source-sans-pro-11}",
           "lineHeight": "{lineHeights.17}",
-          "fontSize": "{fontSize.10}",
+          "fontSize": "{fontSize.12}",
           "letterSpacing": "{letterSpacing.2}",
           "paragraphSpacing": "{paragraphSpacing.0}",
           "textCase": "{textCase.none}",
@@ -400,7 +404,7 @@
         ],
         "type": "boxShadow"
       },
-      "XLarge": {
+      "xlarge": {
         "value": [
           {
             "color": "#0000000a",
@@ -421,7 +425,7 @@
         ],
         "type": "boxShadow"
       },
-      "2XLarge": {
+      "xxlarge": {
         "value": {
           "color": "#00000040",
           "type": "dropShadow",
@@ -538,50 +542,46 @@
         "type": "fontWeights"
       },
       "inter-1": {
-        "value": "Italic",
+        "value": "Bold",
         "type": "fontWeights"
       },
       "inter-2": {
-        "value": "Bold",
-        "type": "fontWeights"
-      },
-      "inter-3": {
         "value": "Semi Bold",
         "type": "fontWeights"
       },
-      "inter-4": {
+      "inter-3": {
         "value": "Medium",
+        "type": "fontWeights"
+      },
+      "sf-pro-text-4": {
+        "value": "Regular",
         "type": "fontWeights"
       },
       "sf-pro-text-5": {
-        "value": "Regular",
-        "type": "fontWeights"
-      },
-      "sf-pro-text-6": {
         "value": "Semibold",
         "type": "fontWeights"
       },
-      "sf-pro-text-7": {
+      "sf-pro-text-6": {
         "value": "Bold",
         "type": "fontWeights"
       },
-      "sf-pro-text-8": {
+      "sf-pro-text-7": {
         "value": "Medium",
         "type": "fontWeights"
       },
-      "inter-9": {
+      "inter-8": {
         "value": "Black",
         "type": "fontWeights"
       },
-      "source-sans-pro-10": {
+      "source-sans-pro-9": {
         "value": "Regular",
         "type": "fontWeights"
       },
-      "source-sans-pro-11": {
+      "source-sans-pro-10": {
         "value": "Bold",
         "type": "fontWeights"
       },
-      "source-sans-pro-12": {
+      "source-sans-pro-11": {
         "value": "SemiBold",
         "type": "fontWeights"
       }
@@ -596,62 +596,90 @@
         "type": "fontSizes"
       },
       "2": {
-        "value": "13",
+        "value": "12.003000259399414",
         "type": "fontSizes"
       },
       "3": {
-        "value": "14",
+        "value": "13",
         "type": "fontSizes"
       },
       "4": {
-        "value": "15",
+        "value": "14",
         "type": "fontSizes"
       },
       "5": {
-        "value": "16",
+        "value": "15",
         "type": "fontSizes"
       },
       "6": {
-        "value": "17",
+        "value": "16",
         "type": "fontSizes"
       },
       "7": {
-        "value": "20",
+        "value": "17",
         "type": "fontSizes"
       },
       "8": {
-        "value": "22",
+        "value": "20",
         "type": "fontSizes"
       },
       "9": {
-        "value": "24",
+        "value": "21.327999114990234",
         "type": "fontSizes"
       },
       "10": {
-        "value": "25",
+        "value": "21.329999923706055",
         "type": "fontSizes"
       },
       "11": {
-        "value": "28",
+        "value": "22",
         "type": "fontSizes"
       },
       "12": {
-        "value": "34",
+        "value": "25",
         "type": "fontSizes"
       },
       "13": {
-        "value": "48",
+        "value": "28",
         "type": "fontSizes"
       },
       "14": {
-        "value": "60",
+        "value": "28.43000030517578",
         "type": "fontSizes"
       },
       "15": {
-        "value": "96",
+        "value": "34",
         "type": "fontSizes"
       },
       "16": {
+        "value": "37.89699935913086",
+        "type": "fontSizes"
+      },
+      "17": {
+        "value": "48",
+        "type": "fontSizes"
+      },
+      "18": {
+        "value": "50.516998291015625",
+        "type": "fontSizes"
+      },
+      "19": {
+        "value": "50.52000045776367",
+        "type": "fontSizes"
+      },
+      "20": {
+        "value": "67.33999633789062",
+        "type": "fontSizes"
+      },
+      "21": {
+        "value": "89.76000213623047",
+        "type": "fontSizes"
+      },
+      "22": {
+        "value": "89.76399993896484",
+        "type": "fontSizes"
+      },
+      "23": {
         "value": "160",
         "type": "fontSizes"
       }
@@ -678,7 +706,7 @@
         "type": "letterSpacing"
       },
       "5": {
-        "value": "0.15",
+        "value": "0",
         "type": "letterSpacing"
       },
       "6": {
@@ -686,11 +714,11 @@
         "type": "letterSpacing"
       },
       "7": {
-        "value": "0.15%",
+        "value": "0.1",
         "type": "letterSpacing"
       },
       "8": {
-        "value": "0.1",
+        "value": "1.25",
         "type": "letterSpacing"
       },
       "9": {
@@ -698,18 +726,10 @@
         "type": "letterSpacing"
       },
       "10": {
-        "value": "1.25",
-        "type": "letterSpacing"
-      },
-      "11": {
         "value": "1.5",
         "type": "letterSpacing"
       },
-      "12": {
-        "value": "0",
-        "type": "letterSpacing"
-      },
-      "13": {
+      "11": {
         "value": "-2",
         "type": "letterSpacing"
       }
@@ -727,49 +747,37 @@
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-0}",
-              "lineHeight": "{lineHeights.0}",
-              "fontSize": "{fontSize.15}",
-              "letterSpacing": "{letterSpacing.0}",
+              "lineHeight": "{lineHeights.1}",
+              "fontSize": "{fontSize.20}",
+              "letterSpacing": "{letterSpacing.1}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
               "textDecoration": "{textDecoration.none}"
             },
             "type": "typography"
           },
-          "italic": {
+          "700": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-1}",
               "lineHeight": "{lineHeights.0}",
-              "fontSize": "{fontSize.15}",
+              "fontSize": "{fontSize.21}",
               "letterSpacing": "{letterSpacing.0}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
               "textDecoration": "{textDecoration.none}"
             },
-            "type": "typography"
-          },
-          "bold": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-2}",
-              "lineHeight": "{lineHeights.0}",
-              "fontSize": "{fontSize.15}",
-              "letterSpacing": "{letterSpacing.0}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
+            "type": "typography",
+            "description": "Bold\n"
           }
         },
         "h2": {
-          "regular": {
+          "400": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-0}",
               "lineHeight": "{lineHeights.1}",
-              "fontSize": "{fontSize.14}",
+              "fontSize": "{fontSize.20}",
               "letterSpacing": "{letterSpacing.1}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -777,25 +785,12 @@
             },
             "type": "typography"
           },
-          "italic": {
+          "700": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-1}",
               "lineHeight": "{lineHeights.1}",
-              "fontSize": "{fontSize.14}",
-              "letterSpacing": "{letterSpacing.1}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
-          },
-          "bold": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-2}",
-              "lineHeight": "{lineHeights.1}",
-              "fontSize": "{fontSize.14}",
+              "fontSize": "{fontSize.20}",
               "letterSpacing": "{letterSpacing.1}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -805,12 +800,12 @@
           }
         },
         "h3": {
-          "regular": {
+          "400": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-0}",
               "lineHeight": "{lineHeights.2}",
-              "fontSize": "{fontSize.13}",
+              "fontSize": "{fontSize.18}",
               "letterSpacing": "{letterSpacing.2}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -818,25 +813,12 @@
             },
             "type": "typography"
           },
-          "italic": {
+          "700": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-1}",
               "lineHeight": "{lineHeights.2}",
-              "fontSize": "{fontSize.13}",
-              "letterSpacing": "{letterSpacing.2}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
-          },
-          "bold": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-2}",
-              "lineHeight": "{lineHeights.2}",
-              "fontSize": "{fontSize.13}",
+              "fontSize": "{fontSize.19}",
               "letterSpacing": "{letterSpacing.2}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -846,12 +828,12 @@
           }
         },
         "h4": {
-          "regular": {
+          "400": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-0}",
               "lineHeight": "{lineHeights.3}",
-              "fontSize": "{fontSize.12}",
+              "fontSize": "{fontSize.16}",
               "letterSpacing": "{letterSpacing.3}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -859,25 +841,12 @@
             },
             "type": "typography"
           },
-          "italic": {
+          "700": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-1}",
               "lineHeight": "{lineHeights.3}",
-              "fontSize": "{fontSize.12}",
-              "letterSpacing": "{letterSpacing.3}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
-          },
-          "bold": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-2}",
-              "lineHeight": "{lineHeights.3}",
-              "fontSize": "{fontSize.12}",
+              "fontSize": "{fontSize.16}",
               "letterSpacing": "{letterSpacing.3}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -887,12 +856,12 @@
           }
         },
         "h5": {
-          "regular": {
+          "400": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-0}",
               "lineHeight": "{lineHeights.4}",
-              "fontSize": "{fontSize.9}",
+              "fontSize": "{fontSize.14}",
               "letterSpacing": "{letterSpacing.4}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -900,25 +869,12 @@
             },
             "type": "typography"
           },
-          "bold": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-2}",
-              "lineHeight": "{lineHeights.4}",
-              "fontSize": "{fontSize.9}",
-              "letterSpacing": "{letterSpacing.4}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
-          },
-          "italic": {
+          "700": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-1}",
               "lineHeight": "{lineHeights.4}",
-              "fontSize": "{fontSize.9}",
+              "fontSize": "{fontSize.14}",
               "letterSpacing": "{letterSpacing.4}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -928,12 +884,12 @@
           }
         },
         "h6": {
-          "regular": {
+          "400": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-0}",
               "lineHeight": "{lineHeights.5}",
-              "fontSize": "{fontSize.7}",
+              "fontSize": "{fontSize.9}",
               "letterSpacing": "{letterSpacing.5}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -941,25 +897,12 @@
             },
             "type": "typography"
           },
-          "italic": {
+          "700": {
             "value": {
               "fontFamily": "{fontFamilies.inter}",
               "fontWeight": "{fontWeights.inter-1}",
               "lineHeight": "{lineHeights.5}",
-              "fontSize": "{fontSize.7}",
-              "letterSpacing": "{letterSpacing.5}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
-          },
-          "bold": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-2}",
-              "lineHeight": "{lineHeights.5}",
-              "fontSize": "{fontSize.7}",
+              "fontSize": "{fontSize.10}",
               "letterSpacing": "{letterSpacing.5}",
               "paragraphSpacing": "{paragraphSpacing.0}",
               "textCase": "{textCase.none}",
@@ -969,13 +912,28 @@
           }
         }
       },
-      "body": {
-        "body1": {
+      "paragraph 1": {
+        "400": {
           "value": {
             "fontFamily": "{fontFamilies.inter}",
             "fontWeight": "{fontWeights.inter-0}",
             "lineHeight": "{lineHeights.5}",
-            "fontSize": "{fontSize.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.6}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography"
+        }
+      },
+      "subtitle1": {
+        "400": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.inter-0}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
             "letterSpacing": "{letterSpacing.6}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
@@ -983,13 +941,13 @@
           },
           "type": "typography"
         },
-        "body2": {
+        "600": {
           "value": {
             "fontFamily": "{fontFamilies.inter}",
-            "fontWeight": "{fontWeights.inter-0}",
+            "fontWeight": "{fontWeights.inter-2}",
             "lineHeight": "{lineHeights.5}",
-            "fontSize": "{fontSize.3}",
-            "letterSpacing": "{letterSpacing.3}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.6}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -997,66 +955,66 @@
           "type": "typography"
         }
       },
-      "subtitle": {
-        "subtitle1": {
-          "regular": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-0}",
-              "lineHeight": "{lineHeights.5}",
-              "fontSize": "{fontSize.5}",
-              "letterSpacing": "{letterSpacing.7}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
+      "paragraph 2": {
+        "400": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.inter-0}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.5}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
           },
-          "semiBold": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-3}",
-              "lineHeight": "{lineHeights.5}",
-              "fontSize": "{fontSize.5}",
-              "letterSpacing": "{letterSpacing.7}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
-          }
+          "type": "typography"
+        }
+      },
+      "subtitle2": {
+        "500": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.inter-3}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.7}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography"
         },
-        "subtitle2": {
-          "medium": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-4}",
-              "lineHeight": "{lineHeights.5}",
-              "fontSize": "{fontSize.3}",
-              "letterSpacing": "{letterSpacing.8}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
+        "600": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.inter-2}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.7}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
           },
-          "semiBold": {
-            "value": {
-              "fontFamily": "{fontFamilies.inter}",
-              "fontWeight": "{fontWeights.inter-3}",
-              "lineHeight": "{lineHeights.5}",
-              "fontSize": "{fontSize.3}",
-              "letterSpacing": "{letterSpacing.8}",
-              "paragraphSpacing": "{paragraphSpacing.0}",
-              "textCase": "{textCase.none}",
-              "textDecoration": "{textDecoration.none}"
-            },
-            "type": "typography"
-          }
+          "type": "typography"
+        }
+      },
+      "button": {
+        "700": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.inter-1}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.8}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography"
         }
       },
       "caption": {
-        "caption": {
+        "400": {
           "value": {
             "fontFamily": "{fontFamilies.inter}",
             "fontWeight": "{fontWeights.inter-0}",
@@ -1070,29 +1028,14 @@
           "type": "typography"
         }
       },
-      "button": {
-        "button": {
-          "value": {
-            "fontFamily": "{fontFamilies.inter}",
-            "fontWeight": "{fontWeights.inter-4}",
-            "lineHeight": "{lineHeights.6}",
-            "fontSize": "{fontSize.3}",
-            "letterSpacing": "{letterSpacing.10}",
-            "paragraphSpacing": "{paragraphSpacing.0}",
-            "textCase": "{textCase.uppercase}",
-            "textDecoration": "{textDecoration.none}"
-          },
-          "type": "typography"
-        }
-      },
       "overline": {
-        "overline": {
+        "600": {
           "value": {
             "fontFamily": "{fontFamilies.inter}",
-            "fontWeight": "{fontWeights.inter-3}",
+            "fontWeight": "{fontWeights.inter-2}",
             "lineHeight": "{lineHeights.6}",
             "fontSize": "{fontSize.1}",
-            "letterSpacing": "{letterSpacing.11}",
+            "letterSpacing": "{letterSpacing.10}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.uppercase}",
             "textDecoration": "{textDecoration.none}"
@@ -1104,10 +1047,10 @@
         "largeTitle": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-5}",
+            "fontWeight": "{fontWeights.sf-pro-text-4}",
             "lineHeight": "{lineHeights.7}",
-            "fontSize": "{fontSize.12}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.15}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1117,10 +1060,10 @@
         "title1": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-6}",
+            "fontWeight": "{fontWeights.sf-pro-text-5}",
             "lineHeight": "{lineHeights.8}",
-            "fontSize": "{fontSize.11}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.13}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1130,10 +1073,10 @@
         "title2": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-6}",
+            "fontWeight": "{fontWeights.sf-pro-text-5}",
             "lineHeight": "{lineHeights.9}",
-            "fontSize": "{fontSize.8}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.11}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1143,10 +1086,10 @@
         "title3": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-6}",
+            "fontWeight": "{fontWeights.sf-pro-text-5}",
             "lineHeight": "{lineHeights.5}",
-            "fontSize": "{fontSize.7}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1156,10 +1099,10 @@
         "headline": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-7}",
+            "fontWeight": "{fontWeights.sf-pro-text-6}",
             "lineHeight": "{lineHeights.10}",
-            "fontSize": "{fontSize.6}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1169,10 +1112,10 @@
         "body": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-5}",
+            "fontWeight": "{fontWeights.sf-pro-text-4}",
             "lineHeight": "{lineHeights.10}",
-            "fontSize": "{fontSize.6}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1182,10 +1125,10 @@
         "largeButton": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-5}",
+            "fontWeight": "{fontWeights.sf-pro-text-4}",
             "lineHeight": "{lineHeights.10}",
-            "fontSize": "{fontSize.6}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1195,10 +1138,10 @@
         "callout": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-8}",
+            "fontWeight": "{fontWeights.sf-pro-text-7}",
             "lineHeight": "{lineHeights.11}",
-            "fontSize": "{fontSize.5}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1208,10 +1151,10 @@
         "subheadline": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-8}",
+            "fontWeight": "{fontWeights.sf-pro-text-7}",
             "lineHeight": "{lineHeights.6}",
-            "fontSize": "{fontSize.3}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.uppercase}",
             "textDecoration": "{textDecoration.none}"
@@ -1221,10 +1164,10 @@
         "smallButton": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-5}",
+            "fontWeight": "{fontWeights.sf-pro-text-4}",
             "lineHeight": "{lineHeights.12}",
-            "fontSize": "{fontSize.4}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1234,10 +1177,10 @@
         "footnote": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-5}",
+            "fontWeight": "{fontWeights.sf-pro-text-4}",
             "lineHeight": "{lineHeights.13}",
-            "fontSize": "{fontSize.2}",
-            "letterSpacing": "{letterSpacing.12}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1247,10 +1190,10 @@
         "caption1": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-5}",
+            "fontWeight": "{fontWeights.sf-pro-text-4}",
             "lineHeight": "{lineHeights.6}",
             "fontSize": "{fontSize.1}",
-            "letterSpacing": "{letterSpacing.12}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"
@@ -1260,10 +1203,10 @@
         "caption2": {
           "value": {
             "fontFamily": "{fontFamilies.sf-pro-text}",
-            "fontWeight": "{fontWeights.sf-pro-text-5}",
+            "fontWeight": "{fontWeights.sf-pro-text-4}",
             "lineHeight": "{lineHeights.14}",
             "fontSize": "{fontSize.0}",
-            "letterSpacing": "{letterSpacing.12}",
+            "letterSpacing": "{letterSpacing.5}",
             "paragraphSpacing": "{paragraphSpacing.0}",
             "textCase": "{textCase.none}",
             "textDecoration": "{textDecoration.none}"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -101,5 +101,8 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
+  "ts-node": {
+    "esm": true
+  },
   "include": ["./action-scripts/**/*", "./*.ts"]
 }


### PR DESCRIPTION
**Fix: Tailwind and MUI typography values were being overwritten. This PR adds a bug fix. **

Adds Tailwind and MUI default typography values. (Priority is given to any property called "regular" or "default." Then it gives priority to the lowest numeric value, now that properties are labeled "400," "500," etc.

Adds two helper scripts to quickly build the MUI and TW files locally.