### PR TITLE
Format generated tokens

### DIFF
--- a/action-scripts/shipwright-script.ts
+++ b/action-scripts/shipwright-script.ts
@@ -26,13 +26,16 @@ const shipwrightScript = async ({
   buildConfig({ transformedTokenPath, outputFolder, styleSystem });
 
   // execute the style-dictionary transformations
-  import("./build.js").then((module) => {
+  await import("./build.js").then((module) => {
     const build = module.default;
     build();
   });
 
   // copy themeFile
   copyThemeFile({ outputFolder, styleSystem, actionPath });
+
+  // format generated token files
+  execSync(`npx prettier --write ${actionPath}${outputFolder}/**`);
 };
 
 export { shipwrightScript };


### PR DESCRIPTION
Generated token files are automatically formatted to be human readable (rather than output in 1 line of code).

Now:
![image](https://user-images.githubusercontent.com/82983755/221286602-20e13d96-3c8f-4b06-a222-3135d4fdf223.png)

Previously:
![image](https://user-images.githubusercontent.com/82983755/221286708-05f4a508-06ff-4233-8b19-ff376316bfe9.png)
